### PR TITLE
Update to repo-config v0.11.0

### DIFF
--- a/.github/containers/test-installation/Dockerfile
+++ b/.github/containers/test-installation/Dockerfile
@@ -3,7 +3,7 @@
 # This Dockerfile is used to test the installation of the python package in
 # multiple platforms in the CI. It is not used to build the package itself.
 
-FROM --platform=${TARGETPLATFORM} python:3.11-slim
+FROM python:3.11-slim
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,11 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,7 +25,7 @@
 #     - changed-files:
 #       - any-glob-to-any-file:
 #         - "src/**/*.py"
-#       - all-glob-to-all-file:
+#       - all-globs-to-all-files:
 #         - "!src/__init__.py"
 #
 # Please have in mind that that the part:xxx labels need to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 68.1.0",
   "setuptools_scm[toml] == 7.1.0",
-  "frequenz-repo-config[lib] == 0.10.0",
+  "frequenz-repo-config[lib] == 0.11.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -59,7 +59,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.5.43",
   "mkdocstrings[python] == 0.26.2",
   "mkdocstrings-python == 1.12.2",
-  "frequenz-repo-config[lib] == 0.10.0",
+  "frequenz-repo-config[lib] == 0.11.0",
 ]
 dev-mypy = [
   "mypy == 1.13.0",
@@ -67,7 +67,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-quantities[dev-mkdocs,dev-noxfile,dev-pytest,marshmallow]",
 ]
-dev-noxfile = ["nox == 2024.10.9", "frequenz-repo-config[lib] == 0.10.0"]
+dev-noxfile = ["nox == 2024.10.9", "frequenz-repo-config[lib] == 0.11.0"]
 dev-pylint = [
   # dev-pytest already defines a dependency to pylint because of the examples
   # For checking the noxfile, docs/ script, and tests
@@ -76,7 +76,7 @@ dev-pylint = [
 dev-pytest = [
   "pytest == 8.3.3",
   "pylint == 3.3.1",                                     # We need this to check for the examples
-  "frequenz-repo-config[extra-lint-examples] == 0.10.0",
+  "frequenz-repo-config[extra-lint-examples] == 0.11.0",
   "pytest-mock == 3.14.0",
   "pytest-asyncio == 0.24.0",
   "async-solipsism == 0.7",
@@ -145,6 +145,8 @@ disable = [
   "unsubscriptable-object",
   # Checked by mypy
   "no-member",
+  "possibly-used-before-assignment",
+  "no-name-in-module",
   # Checked by flake8
   "f-string-without-interpolation",
   "line-too-long",
@@ -158,6 +160,7 @@ disable = [
 [tool.pytest.ini_options]
 testpaths = ["tests", "src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 required_plugins = ["pytest-asyncio", "pytest-mock"]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 
 [build-system]
 requires = [
-  "setuptools == 68.1.0",
-  "setuptools_scm[toml] == 7.1.0",
+  "setuptools == 75.5.0",
+  "setuptools_scm[toml] == 8.1.0",
   "frequenz-repo-config[lib] == 0.11.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We also run the upgrade script to incorporate the changes in the file templates to:

* Avoid docker warnings about `--platform` being redundant.
* Group artifact actions in the dependabot configuration.
* Fix a typo in the labeler configuration.

And we finally also bump the build dependencies, in particular setuptools, so the generated distribution package file name follows PEP625, so they can be uploaded to PyPI.
