### PR TITLE
Add the auto-dependabot GitHub Action workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,22 @@
+name: Auto-merge Dependabot PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@3cad5f42e79296505473325ac6636be897c8b8a1  # v1.3.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dependency-type: 'all'
+          auto-merge: 'true'
+          merge-method: 'merge'
+          add-label: 'tool:auto-merged'


### PR DESCRIPTION
This workflow was added by the repo-config migration script but it was not added to git when committing the changes.
